### PR TITLE
add pytest flake8

### DIFF
--- a/number_parser/parser.py
+++ b/number_parser/parser.py
@@ -297,8 +297,9 @@ def parse(input_string, language=None):
             current_sentence = []
             continue
 
-        elif ((compare_token in lang_data.all_numbers or
-                (_is_skip_token(compare_token, lang_data) and len(tokens_taken) != 0)) and ordinal_number is None):
+        elif (compare_token in lang_data.all_numbers
+              or (_is_skip_token(compare_token, lang_data) and len(tokens_taken) != 0)) \
+                and ordinal_number is None:
             tokens_taken.append(compare_token)
 
         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,15 @@
+[pytest]
+flake8-max-line-length = 119
+flake8-ignore =
+    # This rule goes against the PEP 8 recommended style and it's incompatible
+    # with W504
+    W503
+
+    # Exclude automatically generated files
+    # E501: Line too long
+    number-parser/number_parser/data/* E501
+
+
+    # Exclude files that are meant to provide top-level imports
+    # F401: Module imported but unused
+    number-parser/number_parser/__init__.py F401

--- a/scripts/write_complete_language_data.py
+++ b/scripts/write_complete_language_data.py
@@ -127,7 +127,7 @@ def write_complete_data():
     """
     for file_name in os.listdir(SOURCE_PATH):
         full_source_path = os.path.join(SOURCE_PATH, file_name)
-        full_target_path = os.path.join(TARGET_PATH, file_name.split(".")[0]+".py")
+        full_target_path = os.path.join(TARGET_PATH, file_name.split(".")[0] + ".py")
         full_supplementary_path = os.path.join(SUPPLEMENTARY_PATH, file_name)
 
         language_data = {key: {} for key in REQUIRED_NUMBERS_DATA}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-flake8

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,5 +1,5 @@
 import pytest
-from number_parser import parse, parse_number, parse_ordinal
+from number_parser import parse, parse_number
 from number_parser.parser import _valid_tokens_by_language
 
 

--- a/tests/test_language_ru.py
+++ b/tests/test_language_ru.py
@@ -1,5 +1,5 @@
 import pytest
-from number_parser import parse, parse_number
+from number_parser import parse_number
 from tests import HUNDREDS_DIRECTORY, PERMUTATION_DIRECTORY
 from tests import _test_files
 
@@ -72,7 +72,7 @@ class TestNumberParser():
             ("двадцать одним миллионом", 21_000_000),
         ]
     )
-    def test_parse_number(self,  expected,  test_input):
+    def test_parse_number(self, expected, test_input):
         assert parse_number(test_input, LANG) == expected
 
     def test_parse_number_till_hundred(self):


### PR DESCRIPTION
Add  `pytest-flake8`, add `pytest.ini` file and fix PEP8 (includes)

closes: https://github.com/scrapinghub/number-parser/issues/8