### PR TITLE
Improve scripts

### DIFF
--- a/number_parser_data/supplementary_translation_data/es-419.json
+++ b/number_parser_data/supplementary_translation_data/es-419.json
@@ -1,9 +1,0 @@
-{
-    "UNIT_NUMBERS": {},
-    "DIRECT_NUMBERS": {},
-    "TENS": {},
-    "HUNDREDS": {},
-    "BIG_POWERS_OF_TEN": {},
-    "SKIP_TOKENS": [],
-    "USE_LONG_SCALE": true
-}

--- a/number_parser_data/supplementary_translation_data/root.json
+++ b/number_parser_data/supplementary_translation_data/root.json
@@ -1,8 +1,0 @@
-{
-    "UNIT_NUMBERS": {},
-    "DIRECT_NUMBERS": {},
-    "TENS": {},
-    "HUNDREDS": {},
-    "BIG_POWERS_OF_TEN": {},
-    "SKIP_TOKENS": []
-}

--- a/number_parser_scripts/write_complete_language_data.py
+++ b/number_parser_scripts/write_complete_language_data.py
@@ -107,7 +107,7 @@ def _extract_information(key, word, language_data):
     try:
         number = int(key)
     except ValueError:
-        print("The given key {} is not an integer".format(key))
+        print(f"The given key {key} is not an integer")
         return
 
     word = word.replace(";", '')
@@ -130,8 +130,8 @@ def write_complete_data():
     and write the combined results to the final target directory.
     """
     for file_name in os.listdir(SOURCE_PATH):
-        if file_name == 'root.json':
-            # ignore as it's not a language
+        if file_name in ['root.json', 'es-419.json']:
+            # "root" is not a language, "es-419" doesn't contain spell-out rules
             continue
         full_source_path = os.path.join(SOURCE_PATH, file_name)
         full_target_path = os.path.join(TARGET_PATH, file_name.split(".")[0] + ".py")
@@ -144,7 +144,7 @@ def write_complete_data():
             try:
                 requisite_data = data['rbnf']['rbnf']['SpelloutRules']
             except KeyError:
-                print("This key doesn't exist in {}".format(file_name))
+                logging.error(f"\"['rbnf']['rbnf']['SpelloutRules']\" doesn't exist in {file_name}")
                 continue
 
             for keys, vals in requisite_data.items():
@@ -166,7 +166,7 @@ def write_complete_data():
         try:
             ordered_language_data["USE_LONG_SCALE"] = data["USE_LONG_SCALE"]
         except KeyError:
-            logging.exception("long_scale information missing")
+            logging.error(f"long_scale information missing in {file_name}")
 
         translation_data = json.dumps(ordered_language_data, indent=4, ensure_ascii=False)
         # Overwriting boolean value with capitalized form

--- a/number_parser_scripts/write_complete_language_data.py
+++ b/number_parser_scripts/write_complete_language_data.py
@@ -13,6 +13,10 @@ SOURCE_PATH = "../number_parser_data/raw_cldr_translation_data/"
 SUPPLEMENTARY_PATH = "../number_parser_data/supplementary_translation_data/"
 TARGET_PATH = "../number_parser/data/"
 
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+
 VALID_KEYS = ["spellout-cardinal", "spellout-numbering"]
 INVALID_KEYS = ["cents"]
 CAPTURE_BRACKET_CONTENT = r'\{(.*?)\}'
@@ -126,6 +130,9 @@ def write_complete_data():
     and write the combined results to the final target directory.
     """
     for file_name in os.listdir(SOURCE_PATH):
+        if file_name == 'root.json':
+            # ignore as it's not a language
+            continue
         full_source_path = os.path.join(SOURCE_PATH, file_name)
         full_target_path = os.path.join(TARGET_PATH, file_name.split(".")[0] + ".py")
         full_supplementary_path = os.path.join(SUPPLEMENTARY_PATH, file_name)


### PR DESCRIPTION
1. Avoid `root.json` and `es-419.json` to be imported (fixes: https://github.com/scrapinghub/number-parser/issues/34)

2. `scripts` renamed to `number_parser_scripts` to avoid naming conflicts 