### PR TITLE
Fixed UnicodeDecode and AssertionError in tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@ def get_test_files(path, prefix):
 def _test_files(path, language, is_ordinal=True):
     fnx = parse_ordinal if is_ordinal else parse_number
     for filename in get_test_files(path, f'{language}_'):
-        with open(filename, "r") as csv_file:
+        with open(filename, "r", encoding="utf8") as csv_file:
             csv_reader = csv.DictReader(csv_file)
             for row in csv_reader:
                 try:


### PR DESCRIPTION
Closes #66 
Set the encoding to "utf8" while opening a csv_file in the tests causing 2 AssertionErrors and 4 UnicodeDecode Errors while testing on Windows.